### PR TITLE
Remove unused and duplicate dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,7 +40,6 @@ allprojects {
 }
 
 dependencies {
-    implementation 'com.android.support.constraint:constraint-layout:1.0.2'
     implementation 'com.github.PhilJay:MPAndroidChart:v3.0.3'
     compile fileTree(include: ['*.jar'], dir: 'libs')
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
@@ -49,16 +48,8 @@ dependencies {
     compile 'com.android.support:appcompat-v7:26.1.0'
     compile 'com.android.support:design:26.1.0'
     compile 'com.android.support:support-v4:26.1.0'
-    compile 'org.greenrobot:greendao:3.2.2'
-    compile 'net.zetetic:android-database-sqlcipher:3.5.7'
-
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:26.1.0'
-    compile 'com.android.support:design:26.1.0'
-    compile 'com.android.support:support-v4:26.1.0'
     compile 'com.android.support:cardview-v7:26.1.0'
-    compile 'com.android.support:recyclerview-v7:26.1.0'
-    compile 'com.github.PhilJay:MPAndroidChart:v3.0.0-beta1'
+    compile 'org.greenrobot:greendao:3.2.2'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.json:json:20171018'


### PR DESCRIPTION
This fixes the size regression introduced by version 2.0.

Version 1.9 release size: 2003695 bytes
Version 2.0 release size: 9168767 bytes

Size before this commit: 9136230 bytes
Size after this commit: 2085608 bytes